### PR TITLE
Chinese Date Numerals Convention

### DIFF
--- a/tex/context/base/mkiv/core-con.lua
+++ b/tex/context/base/mkiv/core-con.lua
@@ -621,9 +621,22 @@ local vector = {
     }
 }
 
-local function tochinese(n,name) -- normal, caps, all
- -- improved version by Li Yanrui
+local function tochinese(n,name) -- normal, caps, all, date
+ -- improved version by Li Yanrui, Song Yihan
     local result, r = { }, 0
+
+    if name == "date" then
+        local vector = vector.normal
+
+        local dateStr = tostring(n)
+        for i = 1, #dateStr do
+            r = r + 1
+            result[r] = vector[tonumber(dateStr:sub(i, i))]
+        end
+    
+        return concat(result)
+    end
+
     local vector = vector[name] or vector.normal
     while true do
         if n == 0 then
@@ -708,10 +721,13 @@ converters.tochinese = tochinese
 function converters.chinesenumerals   (n,how) return tochinese(n,how or "normal") end
 function converters.chinesecapnumerals(n)     return tochinese(n,"cap") end
 function converters.chineseallnumerals(n)     return tochinese(n,"all") end
+function converters.chinesedatenumerals(n)     return tochinese(n,"date") end
+
 
 converters['cn']   = converters.chinesenumerals
 converters['cn-c'] = converters.chinesecapnumerals
 converters['cn-a'] = converters.chineseallnumerals
+converters['cn-d'] = converters.chinesedatenumerals
 
 implement {
     name      = "chinesenumerals",

--- a/tex/context/base/mkiv/core-con.mkiv
+++ b/tex/context/base/mkiv/core-con.mkiv
@@ -110,6 +110,7 @@
 \def\chinesenumerals   #1{\clf_chinesenumerals\numexpr#1\relax{normal}}
 \def\chinesecapnumerals#1{\clf_chinesenumerals\numexpr#1\relax{cap}}
 \def\chineseallnumerals#1{\clf_chinesenumerals\numexpr#1\relax{all}}
+\def\chinesedatenumerals#1{\clf_chinesenumerals\numexpr#1\relax{date}}
 
 %D \macros
 %D   {character,Character}
@@ -779,10 +780,12 @@
 \defineconversion [chinesenumerals]      [\chinesenumerals]
 \defineconversion [chinesecapnumerals]   [\chinesecapnumerals]
 \defineconversion [chineseallnumerals]   [\chineseallnumerals]
+\defineconversion [chinesedatenumerals]  [\chinesedatenumerals]
 
 \defineconversion [cn]                   [\chinesenumerals]
 \defineconversion [cn-c]                 [\chinesecapnumerals]
 \defineconversion [cn-a]                 [\chineseallnumerals]
+\defineconversion [cn-d]                 [\chinesedatenumerals]
 
 %D Moved from lang-def.mkiv:
 %D

--- a/tex/context/base/mkxl/core-con.mkxl
+++ b/tex/context/base/mkxl/core-con.mkxl
@@ -118,6 +118,7 @@
 \permanent\def\chinesenumerals   #1{\clf_chinesenumerals\numexpr#1\relax{normal}}
 \permanent\def\chinesecapnumerals#1{\clf_chinesenumerals\numexpr#1\relax{cap}}
 \permanent\def\chineseallnumerals#1{\clf_chinesenumerals\numexpr#1\relax{all}}
+\permanent\def\chinesedatenumerals#1{\clf_chinesenumerals\numexpr#1\relax{date}}
 
 %D \macros
 %D   {character,Character}
@@ -767,10 +768,12 @@
 \defineconversion [chinesenumerals]      [\chinesenumerals]
 \defineconversion [chinesecapnumerals]   [\chinesecapnumerals]
 \defineconversion [chineseallnumerals]   [\chineseallnumerals]
+\defineconversion [chinesedatenumerals]  [\chinesedatenumerals]
 
 \defineconversion [cn]                   [\chinesenumerals]
 \defineconversion [cn-c]                 [\chinesecapnumerals]
 \defineconversion [cn-a]                 [\chineseallnumerals]
+\defineconversion [cn-d]                 [\chinesedatenumerals]
 
 %D Moved from lang-def.mkiv:
 %D


### PR DESCRIPTION
For Chinese date, when use the Chinese numeral conversion, it shouldn't directly follow the common numerals rules, per Chinese Standard [GB/T 15835-2011](http://www.moe.gov.cn/ewebeditor/uploadfile/2015/01/13/20150113091154536.pdf)

![image](https://github.com/contextgarden/context/assets/82010/5a6bb44c-fdb7-4f4b-9f7b-f36f233d22b5)

For example, 2023 should be represented as `二〇二三` instead of `二千零二十三`

The change is pretty straightforward as it introduces an extra parameter called `date`, it would directly convert each digit of the given number to a normal representation without adding extra info.


